### PR TITLE
25. Reverse Nodes in k-groups

### DIFF
--- a/25. Reverse Nodes in k-Group/README.md
+++ b/25. Reverse Nodes in k-Group/README.md
@@ -1,0 +1,32 @@
+# 25. Reverse Nodes in k-Group
+
+## Problem Statement
+
+Given the head of a linked list, reverse the nodes of the list `k` at a time, and return the modified list.
+
+- `k` is a positive integer and is less than or equal to the length of the linked list.
+- If the number of nodes is not a multiple of `k`, then the left-out nodes at the end should remain as they are.
+
+You may not alter the values in the list's nodes; only the nodes themselves may be changed.
+
+### Examples
+
+**Example 1:**
+https://assets.leetcode.com/uploads/2020/10/03/reverse_ex1.jpg
+
+Input: `head = [1,2,3,4,5], k = 2`  
+Output: `[2,1,4,3,5]`
+
+
+
+**Example 2:**
+https://assets.leetcode.com/uploads/2020/10/03/reverse_ex2.jpg
+
+Input: `head = [1,2,3,4,5], k = 3`  
+Output: `[3,2,1,4,5]`
+
+### Constraints
+
+- The number of nodes in the list is `n`.
+- `1 <= k <= n <= 5000`
+- `0 <= Node.val <= 1000`

--- a/25. Reverse Nodes in k-Group/Solution.cpp
+++ b/25. Reverse Nodes in k-Group/Solution.cpp
@@ -1,0 +1,62 @@
+/**
+ * Definition for singly-linked list.
+ * struct ListNode {
+ *     int val;
+ *     ListNode *next;
+ *     ListNode() : val(0), next(nullptr) {}
+ *     ListNode(int x) : val(x), next(nullptr) {}
+ *     ListNode(int x, ListNode *next) : val(x), next(next) {}
+ * };
+ */
+class Solution {
+public:
+    ListNode* reverseLL(ListNode* head)
+    {
+        if(head == NULL || head->next == NULL)
+            return head;
+        ListNode *new_head = reverseLL(head->next);
+        ListNode *front = head->next;
+        front->next = head;
+        head->next = NULL;
+        return new_head;
+    }
+    ListNode* findKthNode(ListNode* temp, int k)
+    {
+        for(int i = 1; i<k;i++)
+        {
+            temp = temp->next;
+            if(temp == NULL)
+                return NULL;
+        }
+        return temp;
+    }
+    ListNode* reverseKGroup(ListNode* head, int k) 
+    {
+        ListNode* ptr = head;
+        ListNode* prevnode = NULL;
+        while(ptr)
+        {
+            ListNode* kthnode = findKthNode(ptr,k);
+            if(kthnode == NULL)
+            {
+                if(prevnode)
+                    prevnode->next = ptr;
+                break;
+            }
+            ListNode* ahead = kthnode->next;
+            kthnode->next = NULL;
+            ListNode* newhead = reverseLL(ptr);
+            if(ptr == head)
+            {
+                head = newhead;
+            }
+            else
+            {
+                prevnode->next = newhead;
+            }
+            prevnode = ptr;
+            ptr = ahead;
+        }
+        return head;
+    }
+};


### PR DESCRIPTION
## Runtime : 0ms
## Memory Used : 16.4mb

The provided solution for the "Reverse Nodes in k-Group" problem effectively reverses the nodes of a singly linked list in groups of size k. The implementation includes a recursive function reverseLL to reverse a segment of the list, ensuring that the next pointers are adjusted correctly. The findKthNode function locates the k-th node from the current position, which is crucial for determining when to reverse the next group. The reverseKGroup function orchestrates the process by iterating through the list, managing the connections between reversed segments, and ensuring that any remaining nodes (fewer than k) are left intact. This approach efficiently handles the requirements while maintaining the integrity of the list structure.