### PR TITLE
Add Python solution for 237 + docs

### DIFF
--- a/237-delete-node-in-a-linked-list/README.md
+++ b/237-delete-node-in-a-linked-list/README.md
@@ -13,6 +13,7 @@
 	<li>All the values after <code>node</code> should be in the same order.</li>
 </ul>
 
+
 <p><strong>Custom testing:</strong></p>
 
 <ul>
@@ -46,4 +47,18 @@
 	<li><code>-1000 &lt;= Node.val &lt;= 1000</code></li>
 	<li>The value of each node in the list is <strong>unique</strong>.</li>
 	<li>The <code>node</code> to be deleted is <strong>in the list</strong> and is <strong>not a tail</strong> node.</li>
+</ul>
+
+<h3>Approach</h3>
+<p>
+We are given only the node to delete, not the head. Copy the value of the <code>next</code>
+node into the current node and then bypass the <code>next</code> node by setting
+<code>node.next = node.next.next</code>. This effectively removes the next node from the list,
+which achieves the desired effect of deleting the given node while preserving order.
+</p>
+
+<h3>Complexity</h3>
+<ul>
+  <li><strong>Time</strong>: <code>O(1)</code></li>
+  <li><strong>Space</strong>: <code>O(1)</code></li>
 </ul>

--- a/237-delete-node-in-a-linked-list/delete-node-in-a-linked-list.cpp
+++ b/237-delete-node-in-a-linked-list/delete-node-in-a-linked-list.cpp
@@ -6,6 +6,10 @@
  *     ListNode(int x) : val(x), next(NULL) {}
  * };
  */
+// Approach: Copy value from next node into current, then bypass next node by
+// setting current->next = current->next->next. This removes the next node,
+// which is equivalent to deleting the given node when head isn't available.
+// Time: O(1), Space: O(1)
 class Solution {
     
 public:

--- a/237-delete-node-in-a-linked-list/delete-node-in-a-linked-list.py
+++ b/237-delete-node-in-a-linked-list/delete-node-in-a-linked-list.py
@@ -1,0 +1,24 @@
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, x):
+#         self.val = x
+#         self.next = None
+
+class Solution:
+    """Delete Node in a Linked List (LeetCode 237)
+
+    Approach:
+        We are given only the node to delete, not the head. Copy the value from
+        the next node into the current node, then bypass the next node by
+        setting current.next = current.next.next. This effectively removes the
+        next node, achieving the required deletion semantics.
+
+    Complexity:
+        Time:  O(1)
+        Space: O(1)
+    """
+
+    def deleteNode(self, node: 'ListNode') -> None:
+        node.val = node.next.val
+        node.next = node.next.next
+


### PR DESCRIPTION
### PR: Add Python solution for 237 + docs

- Add Python O(1) copy-and-bypass solution.
- Document approach and complexity; annotate C++ for consistency.
- Files: `.../delete-node-in-a-linked-list.py`, `README.md`, C++ annotated.