### PR TITLE
Add Python solution for 449 - Serialize and Deserialize BST

### DIFF
--- a/449-serialize-and-deserialize-bst/README.md
+++ b/449-serialize-and-deserialize-bst/README.md
@@ -20,3 +20,30 @@
 	<li><code>0 &lt;= Node.val &lt;= 10<sup>4</sup></code></li>
 	<li>The input tree is <strong>guaranteed</strong> to be a binary search tree.</li>
 </ul>
+
+<hr/>
+
+<h3>Approach</h3>
+<p>
+We serialize the BST using <strong>preorder traversal</strong> (root-left-right), storing only the values as a compact space-separated string. To deserialize, we consume the preorder sequence while enforcing <strong>BST bounds</strong> (<code>min</code>, <code>max</code>) for each subtree. Each value belongs to exactly one interval and is used once, which reconstructs the original BST in linear time.
+</p>
+
+<h4>Steps</h4>
+<ol>
+  <li><strong>Serialize:</strong> Do a preorder DFS and append node values; join by spaces.</li>
+  <li><strong>Deserialize:</strong> Build the tree by reading values in order and recursing with bounds:
+    <ul>
+      <li>Left subtree allowed range: <code>(min, root.val)</code></li>
+      <li>Right subtree allowed range: <code>(root.val, max)</code></li>
+    </ul>
+  </li>
+</ol>
+
+<h4>Complexity</h4>
+<ul>
+  <li><strong>Time:</strong> <code>O(n)</code> for both serialize and deserialize.</li>
+  <li><strong>Space:</strong> <code>O(n)</code> for output and recursion stack in the worst case.</li>
+</ul>
+
+<h4>Python Reference</h4>
+<p>See <code>serialize-and-deserialize-bst.py</code> in this folder.</p>

--- a/449-serialize-and-deserialize-bst/serialize-and-deserialize-bst.py
+++ b/449-serialize-and-deserialize-bst/serialize-and-deserialize-bst.py
@@ -1,0 +1,57 @@
+from typing import Optional, List
+
+
+class Codec:
+    """
+    Serialize and deserialize a Binary Search Tree (BST).
+
+    Approach:
+    - Serialize using preorder traversal (root-left-right). We output values joined by spaces.
+    - Deserialize by consuming the preorder sequence with lower/upper bounds to reconstruct the BST in O(n):
+      each value belongs to exactly one subtree defined by bounds (min_val, max_val).
+
+    Time Complexity: O(n) for both serialize and deserialize, where n is number of nodes.
+    Space Complexity: O(n) for output and recursion stack in worst case (skewed tree).
+    """
+
+    def serialize(self, root: Optional[TreeNode]) -> str:
+        values: List[str] = []
+
+        def preorder(node: Optional[TreeNode]) -> None:
+            if not node:
+                return
+            values.append(str(node.val))
+            preorder(node.left)
+            preorder(node.right)
+
+        preorder(root)
+        return " ".join(values)
+
+    def deserialize(self, data: str) -> Optional[TreeNode]:
+        if not data:
+            return None
+
+        preorder_values: List[int] = list(map(int, data.split()))
+        index: List[int] = [0]  # mutable index captured by closure
+
+        def build(min_val: int, max_val: int) -> Optional[TreeNode]:
+            if index[0] == len(preorder_values):
+                return None
+            val = preorder_values[index[0]]
+            # Enforce strict BST bounds: min_val < val < max_val
+            if not (min_val < val < max_val):
+                return None
+            index[0] += 1
+            node = TreeNode(val)
+            node.left = build(min_val, val)
+            node.right = build(val, max_val)
+            return node
+
+        return build(float('-inf'), float('inf'))
+
+
+# The Codec class will be instantiated and called as such:
+# codec = Codec()
+# codec.deserialize(codec.serialize(root))
+
+


### PR DESCRIPTION
Add Python solution for 449 - Serialize and Deserialize BST

- Add `449-serialize-and-deserialize-bst/serialize-and-deserialize-bst.py`
- Update README with approach and complexities
- Approach: preorder serialize; BST-bounds preorder deserialize
- Complexity: O(n) time, O(n) space